### PR TITLE
Changed jar location back to 'resource/runners' to fix packaging.

### DIFF
--- a/app/helpers/utils.js
+++ b/app/helpers/utils.js
@@ -13,8 +13,8 @@ export function getVusbFilePath() {
   const runner = VUSB_SERVER_NAME;
 
   return process.env.NODE_ENV === 'development'
-    ? join(__dirname, '..', 'resources', runner)
-    : join(process.resourcesPath, runner);
+    ? join(__dirname, '..', 'resources', 'runners', runner)
+    : join(process.resourcesPath, 'runners', runner);
 }
 
 /**

--- a/internals/scripts/downloadVusbJar.js
+++ b/internals/scripts/downloadVusbJar.js
@@ -1,4 +1,4 @@
-const { createWriteStream, unlinkSync, statSync } = require('fs');
+const { createWriteStream, existsSync, mkdirSync, unlinkSync, statSync } = require('fs');
 const { join } = require('path');
 const { get } = require('https');
 
@@ -25,6 +25,10 @@ function downloadFile(url, destination) {
   console.log('💾 Starting to download the vUSB client.');
 
   const request = get(url, (response) => {
+    if (!existsSync('resources/runners')){
+      mkdirSync('resources/runners');
+    }
+    
     const fileStream = createWriteStream(destination);
 
     response.pipe(fileStream);
@@ -70,5 +74,5 @@ function isValidFileSize(filePath) {
 
 downloadFile(
   'https://saucelabs-vusb.s3-eu-west-1.amazonaws.com/v2.0.0/virtual-usb-client.jar',
-  join('resources', 'virtual-usb-client.jar')
+  join('resources/runners', 'virtual-usb-client.jar')
 );


### PR DESCRIPTION
# One-line summary
Proposed fix to packaging not including virtual-usb-client.jar

## Description
Building the lastest code on the repository results in a macOS package without virtual-usb-client.jar
This PR proposes we revert to the previous working directory of "resources/runners", by reverting the changes done on #7  

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
- Configuration change

## Tasks
...

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG