### PR TITLE
Add Access Key login

### DIFF
--- a/app/devices/components/DeviceDetails.jsx
+++ b/app/devices/components/DeviceDetails.jsx
@@ -221,7 +221,8 @@ export default class DeviceDetails extends Component<Props> {
                   className={`${Styles.link} ${
                     sessionID &&
                     deviceConnected &&
-                    manualConnect &&
+                    manualConnect && 
+                    tokenId &&
                     !deviceStopping ?
                       '' :
                       Styles.disabled

--- a/app/devices/components/DeviceDetails.jsx
+++ b/app/devices/components/DeviceDetails.jsx
@@ -241,7 +241,8 @@ export default class DeviceDetails extends Component<Props> {
                   }
                 >
                   {/* When `inUse`, then there is already a live session started in Sauce Labs */}
-                  {inUse ? 'Check the Sauce Labs UI' : 'Launch Live Test'}
+                  {/* Also: we do not want to display the 'Launch...'  message if there's no cookie */}
+                  {inUse || !tokenId ? 'Check the Sauce Labs UI' : 'Launch Live Test'}
                 </a>
               )}
             </div>

--- a/app/login/components/Login.jsx
+++ b/app/login/components/Login.jsx
@@ -243,7 +243,7 @@ export default class Login extends Component<Props> {
                           className={Styles.link}
                           onClick={() =>
                             shell.openExternal(
-                              'https://github.com/ravemir/saucelabs-vusb-app/blob/main/docs/SSO.md'
+                              'https://github.com/saucelabs/saucelabs-vusb-app/blob/main/docs/SSO.md'
                             )
                           }>
                     link

--- a/app/login/components/Login.jsx
+++ b/app/login/components/Login.jsx
@@ -78,7 +78,7 @@ export default class Login extends Component<Props> {
 
       // If signed in with password or SSO Cookie
       if (!isSignInError) {
-        result = await getUserInfo({cookie, username});
+        result = await getUserInfo({cookie_or_key: cookie, user: username});
         isSignInError = await this.verifyError(result);
       }
 
@@ -226,7 +226,7 @@ export default class Login extends Component<Props> {
                     </div>
                     <div className={Styles['form-group']}>
                       <Input
-                        placeholder='Cookie'
+                        placeholder='Access Key/Cookie'
                         name="cookie"
                         onChange={this.handleCookieChange}
                         value={cookie}
@@ -237,18 +237,18 @@ export default class Login extends Component<Props> {
                       disabled={!username || !cookie || isLoading}
                     />
                     <div className={Styles['login_reset']}>
-                      <span>This app can't use SSO, but a workaround is to get a cookie.</span>{' '}
+                      <span>This app can't use SSO, but a workaround is to get an Access Key or a Cookie.</span>{' '}
                       <span>Check the following {' '}
                         <a
                           className={Styles.link}
                           onClick={() =>
                             shell.openExternal(
-                              'https://github.com/saucelabs/saucelabs-vusb-app/blob/main/docs/SSO.md'
+                              'https://github.com/ravemir/saucelabs-vusb-app/blob/main/docs/SSO.md'
                             )
                           }>
                     link
                   </a>
-                        {' '} for more information.
+                        {' '} for more information on both.
                   </span>
                     </div>
                   </form>

--- a/app/login/components/Login.jsx
+++ b/app/login/components/Login.jsx
@@ -78,7 +78,7 @@ export default class Login extends Component<Props> {
 
       // If signed in with password or SSO Cookie
       if (!isSignInError) {
-        result = await getUserInfo({cookie});
+        result = await getUserInfo({cookie, username});
         isSignInError = await this.verifyError(result);
       }
 

--- a/app/login/duck/api.operations.js
+++ b/app/login/duck/api.operations.js
@@ -77,12 +77,13 @@ export function getUserInfo({ cookie_or_key, user=''}) {
           headers: {
             Accept: '/',
             'Cache-Control': 'no-store',
-            Authorization: `Bearer ${cookie}`
+            Authorization: `Bearer ${cookie_or_key}`
           }
         };
         const response = await axios(options);
-        access_key, username = response.data.access_key, response.data.username;
-        dispatch(waiSuccess({ access_key, username, tokenId: cookie }));
+        access_key = response.data.access_key;
+        username = response.data.username;
+        dispatch(waiSuccess({ access_key, username, tokenId: cookie_or_key }));
       }
 
       const { connection } = getGenericStorage();

--- a/app/login/duck/api.operations.js
+++ b/app/login/duck/api.operations.js
@@ -57,12 +57,12 @@ export function authenticate({ username, password }) {
  *
  * @returns {function(*): Promise<void|*|undefined>}
  */
-export function getUserInfo({ cookie }) {
+export function getUserInfo({ cookie, user=''}) {
   return async (dispatch) => {
     // Get the access_key and username
     dispatch(waiStart());
     try {
-      const options = {
+      /*const options = {
         url: waiUrl,
         method: 'GET',
         credentials: 'same-origin',
@@ -73,10 +73,11 @@ export function getUserInfo({ cookie }) {
         }
       };
       const response = await axios(options);
-      const { access_key, username } = response.data;
+      const { access_key, username } = response.data;*/
+      const { access_key, username } = { access_key: cookie , username: 'sso-outsystems-carlos.simoes' }; 
       const { connection } = getGenericStorage();
 
-      dispatch(waiSuccess({ access_key, username, tokenId: cookie }));
+      //dispatch(waiSuccess({ access_key, username, tokenId: cookie }));
 
       return setGenericStorage({
         connection: {

--- a/app/login/duck/api.operations.js
+++ b/app/login/duck/api.operations.js
@@ -67,7 +67,8 @@ export function getUserInfo({ cookie_or_key, user=''}) {
       // Check if token is a GUID, and treat it like an Access Key
       var guid_pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
       if (guid_pattern.test(cookie_or_key)){
-        access_key, username = cookie_or_key , user ; 
+        access_key = cookie_or_key;
+        username = user; 
       } else {
         const options = {
           url: waiUrl,

--- a/app/login/duck/api.operations.js
+++ b/app/login/duck/api.operations.js
@@ -81,7 +81,6 @@ export function getUserInfo({ cookie_or_key, user=''}) {
         };
         const response = await axios(options);
         access_key, username = response.data.access_key, response.data.username;
-        const { connection } = getGenericStorage();
         dispatch(waiSuccess({ access_key, username, tokenId: cookie }));
       }
 

--- a/app/login/duck/api.operations.js
+++ b/app/login/duck/api.operations.js
@@ -53,31 +53,39 @@ export function authenticate({ username, password }) {
 /**
  * Get the user info
  *
- * @param {string} cookie
+ * @param {string} cookie_or_key
  *
  * @returns {function(*): Promise<void|*|undefined>}
  */
-export function getUserInfo({ cookie, user=''}) {
+export function getUserInfo({ cookie_or_key, user=''}) {
   return async (dispatch) => {
     // Get the access_key and username
     dispatch(waiStart());
     try {
-      /*const options = {
-        url: waiUrl,
-        method: 'GET',
-        credentials: 'same-origin',
-        headers: {
-          Accept: '/',
-          'Cache-Control': 'no-store',
-          Authorization: `Bearer ${cookie}`
-        }
-      };
-      const response = await axios(options);
-      const { access_key, username } = response.data;*/
-      const { access_key, username } = { access_key: cookie , username: 'sso-outsystems-carlos.simoes' }; 
-      const { connection } = getGenericStorage();
+      var access_key = "";
+      var username = "";
+      // Check if token is a GUID, and treat it like an Access Key
+      var guid_pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      if (guid_pattern.test(cookie_or_key)){
+        access_key, username = cookie_or_key , user ; 
+      } else {
+        const options = {
+          url: waiUrl,
+          method: 'GET',
+          credentials: 'same-origin',
+          headers: {
+            Accept: '/',
+            'Cache-Control': 'no-store',
+            Authorization: `Bearer ${cookie}`
+          }
+        };
+        const response = await axios(options);
+        access_key, username = response.data.access_key, response.data.username;
+        const { connection } = getGenericStorage();
+        dispatch(waiSuccess({ access_key, username, tokenId: cookie }));
+      }
 
-      //dispatch(waiSuccess({ access_key, username, tokenId: cookie }));
+      const { connection } = getGenericStorage();
 
       return setGenericStorage({
         connection: {

--- a/docs/SSO.md
+++ b/docs/SSO.md
@@ -2,7 +2,16 @@
 If your organisation if using SSO then you have a `username`, but you don't have a `password`. The Sauce Labs vUSB GUI
 is not connected to SSO, but there is a workaround which will let you use this tool and is explained below.
 
-## SSO workaround
+## SSO workarounds
+The original app only used the cookie method to allow access, but given it used the access key behind the scenes, it was easy enough to add.
+
+### Access Key
+1. Login to your Sauce Labs account using the usual SSO method
+1. When you are signed in, go to **Account** > **User Settings** and copy the `username` and fill it in the 
+   SSO-`username` field. (*This value will automatically be stored for future sign in sessions.*)
+1. On the same screen, copy the `access_key` and fill it in the `access_key/cookie` field.
+
+### Cookie
 When you [sign in to the Sauce Labs cloud](https://accounts.saucelabs.com), Sauce Labs will set a cookie which is called 
 the `sl-auth`-cookie. The workaround is to copy the cookie from Sauce Labs and fill it in the `cookie` field. 
 Please follow the following steps to use SSO with vUSB. 
@@ -30,7 +39,7 @@ Please follow the following steps to use SSO with vUSB.
 
    ![Search Cookie](assets/search-cookie.png) 
 
-1. Copy the value and paste it into the SSO Sign in form in the `cookie`-field as seen below
+1. Copy the value and paste it into the SSO Sign in form in the `access_key/cookie`-field as seen below
 
    ![SSO cookie field](assets/sso-cookie.png) 
 


### PR DESCRIPTION
# One-line summary
Add Access Key login capabilities, since most of functionality only relies on it anyway

## Description
While studying the app for adoption, we found that it uses a "workaround" to allow SSO login (which is what we use)
This is acceptable, but looks slightly more cumbersome+error prone, so we wanted to add an alternative way.
After inspection, we realized that Access Keys are obtained immediately after login with Cookies, indicating that it might be the only credentials used for the remainder of the app.
While this is not strictly true (the "Launch Live Test" option in the "DeviceDetails" component is an example), we can adjust the remaining cases to be off-limits while using this method.

## Types of Changes
- New feature
- Configuration change

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Change UI and API operations to allow interchangeable Access Key+Cookie login for SSO
  - [ ] Adjust Opening of Sauce Labs Sessions from app to not crash when Access Key is used

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG